### PR TITLE
Integrated with VirtualTimer library

### DIFF
--- a/include/can_interface.h
+++ b/include/can_interface.h
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <chrono>
+#include <functional>
 #include <vector>
 
 #include "virtualTimer.h"
@@ -158,7 +159,7 @@ public:
           signals_{&signals...}
     {
         static_assert(sizeof...(signals) == num_signals, "Wrong number of signals passed into CANTXMessage.");
-        transmit_timer_.Start(start_time);
+        // transmit_timer_.Start(start_time);
     }
 
     template <typename... Ts>
@@ -203,12 +204,12 @@ private:
 
     void EncodeSignals()
     {
-        uint64_t temp_raw{0};
+        uint8_t *temp_raw[8]{0};
         for (uint8_t i = 0; i < num_signals; i++)
         {
-            signals_[i]->EncodeSignal(&temp_raw);
+            signals_[i]->EncodeSignal(reinterpret_cast<uint64_t *>(temp_raw));
         }
-        *reinterpret_cast<uint64_t *>(message_.data_.data()) = temp_raw;
+        std::copy(std::begin(temp_raw), std::end(temp_raw), std::begin(message_.data_));
     }
 };
 

--- a/include/can_interface.h
+++ b/include/can_interface.h
@@ -246,12 +246,12 @@ private:
 
     void EncodeSignals()
     {
-        uint8_t *temp_raw[8]{0};
+        uint8_t temp_raw[8]{0};
         for (uint8_t i = 0; i < num_signals; i++)
         {
             signals_[i]->EncodeSignal(reinterpret_cast<uint64_t *>(temp_raw));
         }
-        std::copy(std::begin(temp_raw), std::end(temp_raw), std::begin(message_.data_));
+        std::copy(std::begin(temp_raw), std::end(temp_raw), message_.data_.begin());
     }
 };
 

--- a/include/can_interface.h
+++ b/include/can_interface.h
@@ -144,7 +144,7 @@ public:
     CANTXMessage(ICAN &can_interface, uint16_t id, uint8_t length, uint32_t period, uint32_t start_time, Ts &...signals)
         : can_interface_{can_interface},
           message_{id, length, std::array<uint8_t, 8>()},
-          transmit_timer_{period, EncodeAndSend, VirtualTimer::Type::kRepeating},
+          transmit_timer_{period, [this]() { this->EncodeAndSend(); }, VirtualTimer::Type::kRepeating},
           signals_{&signals...}
     {
         static_assert(sizeof...(signals) == num_signals, "Wrong number of signals passed into CANTXMessage.");

--- a/include/can_interface.h
+++ b/include/can_interface.h
@@ -194,14 +194,13 @@ public:
      * @param start_time The time in ms to start transmitting the message
      * @param signals The ICANSignals contained in the message
      */
-    CANTXMessage(ICAN &can_interface, uint16_t id, uint8_t length, uint32_t period, uint32_t start_time, Ts &...signals)
+    CANTXMessage(ICAN &can_interface, uint16_t id, uint8_t length, uint32_t period, Ts &...signals)
         : can_interface_{can_interface},
           message_{id, length, std::array<uint8_t, 8>()},
           transmit_timer_{period, [this]() { this->EncodeAndSend(); }, VirtualTimer::Type::kRepeating},
           signals_{&signals...}
     {
         static_assert(sizeof...(signals) == num_signals, "Wrong number of signals passed into CANTXMessage.");
-        // transmit_timer_.Start(start_time);
     }
 
     template <typename... Ts>
@@ -220,10 +219,9 @@ public:
                  uint16_t id,
                  uint8_t length,
                  uint32_t period,
-                 uint32_t start_time,
-                 VirtualTimerGroup timer_group,
+                 VirtualTimerGroup &timer_group,
                  Ts &...signals)
-        : CANTXMessage(can_interface, id, length, period, start_time, signals...)
+        : CANTXMessage(can_interface, id, length, period, signals...)
     {
         timer_group.AddTimer(transmit_timer_);
     }

--- a/include/can_interface.h
+++ b/include/can_interface.h
@@ -180,7 +180,7 @@ public:
                  uint32_t start_time,
                  VirtualTimerGroup timer_group,
                  Ts &...signals)
-        : CANTXMessage(can_interface, id, length, period, start_time, &signals...)
+        : CANTXMessage(can_interface, id, length, period, start_time, signals...)
     {
         timer_group.AddTimer(transmit_timer_);
     }

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,20 +20,24 @@ board = esp32dev
 framework = arduino
 monitor_speed = 115200
 lib_deps = miwagner/ESP32CAN@^0.0.1
+            https://github.com/NU-Formula-Racing/timers.git#bugfix/nullptrAndFormat
 
 [env:teensy40]
 platform = teensy
 board = teensy40
 framework = arduino
 monitor_speed = 115200
+lib_deps = https://github.com/NU-Formula-Racing/timers.git
 
 [env:teensy41]
 platform = teensy
 board = teensy41
 framework = arduino
 monitor_speed = 115200
+lib_deps = https://github.com/NU-Formula-Racing/timers.git
 
 [env:native]
 platform = native
 test_framework = unity
 debug_test = *
+lib_deps = https://github.com/NU-Formula-Racing/timers.git

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,7 +20,7 @@ board = esp32dev
 framework = arduino
 monitor_speed = 115200
 lib_deps = miwagner/ESP32CAN@^0.0.1
-            https://github.com/NU-Formula-Racing/timers.git#bugfix/nullptrAndFormat
+            https://github.com/NU-Formula-Racing/timers.git
 
 [env:teensy40]
 platform = teensy


### PR DESCRIPTION
BREAKING: This PR changes how ticking TX messages works, as they now must be ticked through their VirtualTimers.

Tested on ESP32 and Teensy 4.0 with CAN_Interface_Demo