### PR TITLE
Fixed can on V2+ ESP32 chips

### DIFF
--- a/src/ESP32CAN/CAN.c
+++ b/src/ESP32CAN/CAN.c
@@ -230,6 +230,9 @@ int CAN_init()
     // enable all interrupts
     MODULE_CAN->IER.U = 0xff;
 
+    //disable bit that can be wake-up interrupt enable or divide baud rate by 2
+    MODULE_CAN->IER.B.WUIE = 0;
+
     // Set acceptance filter
     MODULE_CAN->MOD.B.AFM = __filter.FM;
     MODULE_CAN->MBX_CTRL.ACC.CODE[0] = __filter.ACR0;


### PR DESCRIPTION
Fixed baud rate being set to half what we want on V2+ chips due to redefinition of wakeup interrupt enable register to half baud rate